### PR TITLE
Add Python 3.12 remove 3.6, 3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,12 +13,11 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - {python: "3.6", os: "ubuntu-20.04"}
-          - {python: "3.7", os: "ubuntu-latest"}
           - {python: "3.8", os: "ubuntu-latest"}
           - {python: "3.9", os: "ubuntu-latest"}
           - {python: "3.10", os: "ubuntu-latest"}
           - {python: "3.11", os: "ubuntu-latest"}
+          - {python: "3.12", os: "ubuntu-latest"}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,5 +37,5 @@ jobs:
       - name: Run Python tests
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install -e .[test]
+          python3 -m pip install .[test]
           pytest

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -58,7 +58,7 @@ jobs:
         brew install flex
         echo "/usr/local/opt/flex/bin" >> $GITHUB_PATH
 
-    - uses: pypa/cibuildwheel@v2.12.1
+    - uses: pypa/cibuildwheel@v2.16
       env:
         CIBW_BEFORE_ALL_LINUX: |
           yum --disablerepo=epel -y update ca-certificates
@@ -113,7 +113,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [cp36-cp36m, cp37-cp37m, cp38-cp38, cp39-cp39, cp310-cp310, cp311-cp311]
+        python: [cp38-cp38, cp39-cp39, cp310-cp310, cp311-cp311, cp312-cp312]
     steps:
     - uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,11 +12,12 @@ env:
 
 jobs:
   build_wheels:
-    name: Wheels leflib on ${{ matrix.platform.os }} ${{ matrix.platform.arch}}
+    name: Wheels leflib on ${{ matrix.platform.os }} ${{ matrix.platform.arch}} ${{ matrix.python-version }}
     runs-on: ${{ matrix.platform.os }}
     strategy:
       fail-fast: false
       matrix:
+        python-version: [cp38*, cp39*, cp310*, cp311*, cp312*]
         platform:
           - os: ubuntu-latest
             arch: x86_64
@@ -69,6 +70,7 @@ jobs:
           CPPFLAGS="-I/usr/local/opt/flex/include"
         CIBW_ENVIRONMENT_WINDOWS: SC_CMAKEARGS="-DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake."
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+        CIBW_BUILD: ${{ matrix.python-version }}
         CIBW_SKIP: "pp* *win32 *i686 *-musllinux_*"
         CIBW_ARCHS_MACOS: x86_64 arm64
         CIBW_TEST_SKIP: "*_arm64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=45,<64",
+    "setuptools>=45",
     "wheel",
     "cython",
     "scikit-build>=0.12",

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
     version=get_version(),
     packages=["sc_leflib"],
 
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     install_requires=install_reqs,
     extras_require=extras_req,
     **skbuild_args


### PR DESCRIPTION
**What?**
Upgraded Python version, deprecated old ones, parallellized build

**Why?**
Prerequisite to supporting python 3.12 in siliconcompiler

**Wheels build:**
Build time is now 20m instead of 1h30m
https://github.com/siliconcompiler/sc-leflib/actions/runs/6509323413

**Note:**
For some reason the editable installs [are broken](https://github.com/scikit-build/scikit-build/issues/1025) with newer versions of setuptools + skbuild.
Now that we have separated out sc-leflib using the non editable installs should be fine for testing. Siliconcompiler itself can still be installed in editable mode.